### PR TITLE
sowm: scope client more locally

### DIFF
--- a/sowm.c
+++ b/sowm.c
@@ -77,7 +77,7 @@ static void (*events[LASTEvent])(XEvent *e) = {
 #include "config.h"
 
 // Iterate over the current desktop's window list.
-#define win (c=list;c;c=c->next)
+#define win (client *c=list;c;c=c->next)
 
 // Focus the given window.
 #define win_focus(W) XSetInputFocus(d, W, RevertToParent, CurrentTime);
@@ -237,8 +237,6 @@ void button_press(XEvent *e) {
    no longer at 0,0+[screen_width]X[screen_height].
 */
 void button_release() {
-    client *c;
-
     for win if (c->w == mouse.subwindow) c->f = 0;
 
     mouse.subwindow = None;
@@ -282,8 +280,6 @@ void win_add(Window w) {
    is updated.
 */
 void win_del(Window w) {
-    client *c;
-
     for win if (c->w == w) {
         if (!c->prev && !c->next) {
             free(list);
@@ -355,8 +351,6 @@ void win_center(const Arg arg) {
    the window is un-fullscreened.
 */
 void win_fs() {
-    client *c;
-
     win_current();
 
     for win if (c->w == cur) {
@@ -411,15 +405,13 @@ void win_to_ws(const Arg arg) {
 */
 void win_next() {
     win_current();
-    client *c;
 
-    if (list) {
-        for win if (c->w == cur) break;
-
+    for win if (c->w == cur) {
         c = c->next ? c->next : list;
 
         win_focus(c->w);
         XRaiseWindow(d, c->w);
+        return;
     }
 }
 
@@ -434,7 +426,6 @@ void win_next() {
     destination desktop's window list.
 */
 void ws_go(const Arg arg) {
-    client *c;
     int tmp = ws;
 
     if (arg.i == ws) return;


### PR DESCRIPTION
Rationale:

- Reduces the scope of the `c`  variable to the loop it is now declared in. 

Issues:

- `win_next()` no longer cycles back to the start of the list.