### PR TITLE
Add patch which provides primitive multimonitor functionality

### DIFF
--- a/patches/sowm-primitive-multimonitor.patch
+++ b/patches/sowm-primitive-multimonitor.patch
@@ -1,0 +1,104 @@
+diff --git a/Makefile b/Makefile
+index 8573837..72e9542 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,5 @@
+ CFLAGS+= -std=c99 -Wall -Wextra -pedantic
+-LDADD+= -lX11
++LDADD+= -lX11 -lXinerama
+ LDFLAGS=
+ PREFIX?= /usr
+ BINDIR?= $(PREFIX)/bin
+diff --git a/sowm.c b/sowm.c
+index 0cc1293..27c51ce 100644
+--- a/sowm.c
++++ b/sowm.c
+@@ -4,9 +4,11 @@
+ #include <X11/XF86keysym.h>
+ #include <X11/keysym.h>
+ #include <X11/XKBlib.h>
++#include<X11/extensions/Xinerama.h>
+ #include <stdlib.h>
+ #include <signal.h>
+ #include <unistd.h>
++#include <stdbool.h>
+ 
+ typedef union {
+     const char** com;
+@@ -97,6 +99,7 @@ void notify_enter(XEvent *e) {
+ 
+ void notify_motion(XEvent *e) {
+     if (!mouse.subwindow) return;
++    if (cur->f == 1) return;
+ 
+     while(XCheckTypedEvent(d, MotionNotify, e));
+ 
+@@ -108,6 +111,7 @@ void notify_motion(XEvent *e) {
+         wy + (mouse.button == 1 ? yd : 0),
+         ww + (mouse.button == 3 ? xd : 0),
+         wh + (mouse.button == 3 ? yd : 0));
++    win_size(cur->w, &cur->wx, &cur->wy, &cur->ww, &cur->wh);
+ }
+ 
+ void key_press(XEvent *e) {
+@@ -172,12 +176,37 @@ void win_kill() {
+     if (cur) XKillClient(d, cur->w);
+ }
+ 
++bool coords_in_box (int x, int y, int box_x, int box_y, int box_w, int box_h) {
++    if ((x >= box_x && x < box_x + box_w) && (y >= box_y && y < box_y + box_h))
++        return true;
++    else
++        return false;
++}
++
+ void win_center() {
+     if (!cur) return;
+ 
+     win_size(cur->w, &(int){0}, &(int){0}, &ww, &wh);
+ 
+-    XMoveWindow(d, cur->w, (sw - ww) / 2, (sh - wh) / 2);
++    if (XineramaIsActive(d)) {
++        int number_of_monitors;
++        XineramaScreenInfo *screen_info = XineramaQueryScreens(d, &number_of_monitors);
++        /* Checking on which monitor the origin of the window is. Technically it
++         * would be better to check for the center of the window, but that is
++         * only relevant in the edge case when a window is displayed on multiple
++         * outputs simultaneously.
++         */
++        for (int i = 0; i < number_of_monitors; i++) {
++            if (coords_in_box(cur->wx, cur->wy,
++                screen_info[i].x_org, screen_info[i].y_org,
++                screen_info[i].width, screen_info[i].height))
++                XMoveWindow(d, cur->w,
++                            screen_info[i].x_org + ((screen_info[i].width  - ww) / 2),
++                            screen_info[i].y_org + ((screen_info[i].height - wh) / 2));
++        }
++    } else
++        XMoveWindow(d, cur->w, (sw - ww) / 2, (sh - wh) / 2);
++    win_size(cur->w, &cur->wx, &cur->wy, &cur->ww, &cur->wh);
+ }
+ 
+ void win_fs() {
+@@ -185,8 +214,19 @@ void win_fs() {
+ 
+     if ((cur->f = cur->f ? 0 : 1)) {
+         win_size(cur->w, &cur->wx, &cur->wy, &cur->ww, &cur->wh);
+-        XMoveResizeWindow(d, cur->w, 0, 0, sw, sh);
+-
++        if (XineramaIsActive(d)) {
++            int number_of_monitors;
++            XineramaScreenInfo *screen_info = XineramaQueryScreens(d, &number_of_monitors);
++            for (int i = 0; i < number_of_monitors; i++) {
++                if (coords_in_box(cur->wx, cur->wy,
++                    screen_info[i].x_org, screen_info[i].y_org,
++                    screen_info[i].width, screen_info[i].height))
++                    XMoveResizeWindow(d, cur->w,
++                                      screen_info[i].x_org, screen_info[i].y_org,
++                                      screen_info[i].width, screen_info[i].height);
++            }
++        } else
++            XMoveResizeWindow(d, cur->w, 0, 0, sw, sh);
+     } else
+         XMoveResizeWindow(d, cur->w, cur->wx, cur->wy, cur->ww, cur->wh);
+ }

--- a/patches/sowm-primitive-multimonitor.patch
+++ b/patches/sowm-primitive-multimonitor.patch
@@ -10,7 +10,7 @@ index 8573837..72e9542 100644
  PREFIX?= /usr
  BINDIR?= $(PREFIX)/bin
 diff --git a/sowm.c b/sowm.c
-index 0cc1293..665b0f8 100644
+index 0cc1293..fa911b0 100644
 --- a/sowm.c
 +++ b/sowm.c
 @@ -4,6 +4,7 @@
@@ -38,29 +38,28 @@ index 0cc1293..665b0f8 100644
  }
  
  void key_press(XEvent *e) {
-@@ -172,12 +174,36 @@ void win_kill() {
+@@ -172,12 +174,35 @@ void win_kill() {
      if (cur) XKillClient(d, cur->w);
  }
  
 +int multimonitor_center_fs (int fs) {
-+    if (XineramaIsActive(d)) {
-+        XineramaScreenInfo *screen_info = XineramaQueryScreens(d, &monitors);
-+        for (int i = 0; i < monitors; i++) {
-+            if ((cur->wx >= screen_info[i].x_org && cur->wx < screen_info[i].x_org + screen_info[i].width)
-+                && (cur->wy >= screen_info[i].y_org && cur->wy < screen_info[i].y_org + screen_info[i].height)) {
-+                if (fs)
-+                    XMoveResizeWindow(d, cur->w,
-+                                      screen_info[i].x_org, screen_info[i].y_org,
-+                                      screen_info[i].width, screen_info[i].height);
-+                else
-+                    XMoveWindow(d, cur->w,
-+                                screen_info[i].x_org + ((screen_info[i].width  - ww) / 2),
-+                                screen_info[i].y_org + ((screen_info[i].height - wh) / 2));
-+            }
-+            return 0;
++    if (!XineramaIsActive(d))
++        return 1;
++    XineramaScreenInfo *screen_info = XineramaQueryScreens(d, &monitors);
++    for (int i = 0; i < monitors; i++) {
++        if ((cur->wx >= screen_info[i].x_org && cur->wx < screen_info[i].x_org + screen_info[i].width)
++            && (cur->wy >= screen_info[i].y_org && cur->wy < screen_info[i].y_org + screen_info[i].height)) {
++            if (fs)
++                XMoveResizeWindow(d, cur->w,
++                                  screen_info[i].x_org, screen_info[i].y_org,
++                                  screen_info[i].width, screen_info[i].height);
++            else
++                XMoveWindow(d, cur->w,
++                            screen_info[i].x_org + ((screen_info[i].width  - ww) / 2),
++                            screen_info[i].y_org + ((screen_info[i].height - wh) / 2));
 +        }
 +    }
-+    return 1;
++    return 0;
 +}
 +
  void win_center() {
@@ -76,7 +75,7 @@ index 0cc1293..665b0f8 100644
  }
  
  void win_fs() {
-@@ -185,8 +211,8 @@ void win_fs() {
+@@ -185,8 +210,8 @@ void win_fs() {
  
      if ((cur->f = cur->f ? 0 : 1)) {
          win_size(cur->w, &cur->wx, &cur->wy, &cur->ww, &cur->wh);

--- a/patches/sowm-primitive-multimonitor.patch
+++ b/patches/sowm-primitive-multimonitor.patch
@@ -17,7 +17,7 @@ index 0cc1293..27c51ce 100644
  #include <X11/XF86keysym.h>
  #include <X11/keysym.h>
  #include <X11/XKBlib.h>
-+#include<X11/extensions/Xinerama.h>
++#include <X11/extensions/Xinerama.h>
  #include <stdlib.h>
  #include <signal.h>
  #include <unistd.h>

--- a/patches/sowm-primitive-multimonitor.patch
+++ b/patches/sowm-primitive-multimonitor.patch
@@ -40,15 +40,12 @@ index 0cc1293..27c51ce 100644
  }
  
  void key_press(XEvent *e) {
-@@ -172,12 +171,32 @@ void win_kill() {
+@@ -172,12 +171,29 @@ void win_kill() {
      if (cur) XKillClient(d, cur->w);
  }
  
 +int coords_in_box (int x, int y, int box_x, int box_y, int box_w, int box_h) {
-+    if ((x >= box_x && x < box_x + box_w) && (y >= box_y && y < box_y + box_h))
-+        return 1;
-+    else
-+        return 0;
++    return ((x >= box_x && x < box_x + box_w) && (y >= box_y && y < box_y + box_h));
 +}
 +
  void win_center() {

--- a/patches/sowm-primitive-multimonitor.patch
+++ b/patches/sowm-primitive-multimonitor.patch
@@ -10,7 +10,7 @@ index 8573837..72e9542 100644
  PREFIX?= /usr
  BINDIR?= $(PREFIX)/bin
 diff --git a/sowm.c b/sowm.c
-index 0cc1293..e8cbce6 100644
+index 0cc1293..6f858a9 100644
 --- a/sowm.c
 +++ b/sowm.c
 @@ -4,6 +4,7 @@
@@ -38,7 +38,7 @@ index 0cc1293..e8cbce6 100644
  }
  
  void key_press(XEvent *e) {
-@@ -172,12 +174,34 @@ void win_kill() {
+@@ -172,12 +174,35 @@ void win_kill() {
      if (cur) XKillClient(d, cur->w);
  }
  
@@ -56,6 +56,7 @@ index 0cc1293..e8cbce6 100644
 +                XMoveWindow(d, cur->w,
 +                            screen_info[i].x_org + ((screen_info[i].width  - ww) / 2),
 +                            screen_info[i].y_org + ((screen_info[i].height - wh) / 2));
++            break;
 +        }
 +    }
 +    return 0;
@@ -74,7 +75,7 @@ index 0cc1293..e8cbce6 100644
  }
  
  void win_fs() {
-@@ -185,8 +209,8 @@ void win_fs() {
+@@ -185,8 +210,8 @@ void win_fs() {
  
      if ((cur->f = cur->f ? 0 : 1)) {
          win_size(cur->w, &cur->wx, &cur->wy, &cur->ww, &cur->wh);

--- a/patches/sowm-primitive-multimonitor.patch
+++ b/patches/sowm-primitive-multimonitor.patch
@@ -10,7 +10,7 @@ index 8573837..72e9542 100644
  PREFIX?= /usr
  BINDIR?= $(PREFIX)/bin
 diff --git a/sowm.c b/sowm.c
-index 0cc1293..ead3f6c 100644
+index 0cc1293..40b39dd 100644
 --- a/sowm.c
 +++ b/sowm.c
 @@ -4,6 +4,7 @@
@@ -30,15 +30,7 @@ index 0cc1293..ead3f6c 100644
  static unsigned int ww, wh;
  
  static Display      *d;
-@@ -97,6 +98,7 @@ void notify_enter(XEvent *e) {
- 
- void notify_motion(XEvent *e) {
-     if (!mouse.subwindow) return;
-+    if (cur->f == 1) return;
- 
-     while(XCheckTypedEvent(d, MotionNotify, e));
- 
-@@ -108,6 +110,7 @@ void notify_motion(XEvent *e) {
+@@ -108,6 +109,7 @@ void notify_motion(XEvent *e) {
          wy + (mouse.button == 1 ? yd : 0),
          ww + (mouse.button == 3 ? xd : 0),
          wh + (mouse.button == 3 ? yd : 0));
@@ -46,12 +38,34 @@ index 0cc1293..ead3f6c 100644
  }
  
  void key_press(XEvent *e) {
-@@ -172,12 +175,28 @@ void win_kill() {
+@@ -172,12 +174,41 @@ void win_kill() {
      if (cur) XKillClient(d, cur->w);
  }
  
 +int coords_in_box (int x, int y, int box_x, int box_y, int box_w, int box_h) {
 +    return ((x >= box_x && x < box_x + box_w) && (y >= box_y && y < box_y + box_h));
++}
++
++int multimonitor_center_fs (int fs) {
++    if (XineramaIsActive(d)) {
++        XineramaScreenInfo *screen_info = XineramaQueryScreens(d, &monitors);
++        for (int i = 0; i < monitors; i++) {
++            if (coords_in_box(cur->wx + (cur->ww / 2), cur->wy + (cur->wh / 2),
++                screen_info[i].x_org, screen_info[i].y_org,
++                screen_info[i].width, screen_info[i].height)) {
++                if (fs)
++                    XMoveResizeWindow(d, cur->w,
++                                      screen_info[i].x_org, screen_info[i].y_org,
++                                      screen_info[i].width, screen_info[i].height);
++                else
++                    XMoveWindow(d, cur->w,
++                                screen_info[i].x_org + ((screen_info[i].width  - ww) / 2),
++                                screen_info[i].y_org + ((screen_info[i].height - wh) / 2));
++            }
++            return 0;
++        }
++    }
++    return 1;
 +}
 +
  void win_center() {
@@ -60,39 +74,20 @@ index 0cc1293..ead3f6c 100644
      win_size(cur->w, &(int){0}, &(int){0}, &ww, &wh);
  
 -    XMoveWindow(d, cur->w, (sw - ww) / 2, (sh - wh) / 2);
-+    if (XineramaIsActive(d)) {
-+        XineramaScreenInfo *screen_info = XineramaQueryScreens(d, &monitors);
-+        for (int i = 0; i < monitors; i++) {
-+            if (coords_in_box(cur->wx + (cur->ww / 2), cur->wy + (cur->wh / 2),
-+                screen_info[i].x_org, screen_info[i].y_org,
-+                screen_info[i].width, screen_info[i].height))
-+                XMoveWindow(d, cur->w,
-+                            screen_info[i].x_org + ((screen_info[i].width  - ww) / 2),
-+                            screen_info[i].y_org + ((screen_info[i].height - wh) / 2));
-+        }
-+    } else
++    if (multimonitor_center_fs(0))
 +        XMoveWindow(d, cur->w, (sw - ww) / 2, (sh - wh) / 2);
++
 +    win_size(cur->w, &cur->wx, &cur->wy, &cur->ww, &cur->wh);
  }
  
  void win_fs() {
-@@ -185,8 +204,18 @@ void win_fs() {
+@@ -185,8 +216,8 @@ void win_fs() {
  
      if ((cur->f = cur->f ? 0 : 1)) {
          win_size(cur->w, &cur->wx, &cur->wy, &cur->ww, &cur->wh);
 -        XMoveResizeWindow(d, cur->w, 0, 0, sw, sh);
 -
-+        if (XineramaIsActive(d)) {
-+            XineramaScreenInfo *screen_info = XineramaQueryScreens(d, &monitors);
-+            for (int i = 0; i < monitors; i++) {
-+                if (coords_in_box(cur->wx + (cur->ww / 2), cur->wy + (cur->wh / 2),
-+                    screen_info[i].x_org, screen_info[i].y_org,
-+                    screen_info[i].width, screen_info[i].height))
-+                    XMoveResizeWindow(d, cur->w,
-+                                      screen_info[i].x_org, screen_info[i].y_org,
-+                                      screen_info[i].width, screen_info[i].height);
-+            }
-+        } else
++        if(multimonitor_center_fs(1))
 +            XMoveResizeWindow(d, cur->w, 0, 0, sw, sh);
      } else
          XMoveResizeWindow(d, cur->w, cur->wx, cur->wy, cur->ww, cur->wh);

--- a/patches/sowm-primitive-multimonitor.patch
+++ b/patches/sowm-primitive-multimonitor.patch
@@ -41,7 +41,7 @@ index 0cc1293..27c51ce 100644
  }
  
  void key_press(XEvent *e) {
-@@ -172,12 +176,37 @@ void win_kill() {
+@@ -172,12 +171,32 @@ void win_kill() {
      if (cur) XKillClient(d, cur->w);
  }
  
@@ -61,13 +61,8 @@ index 0cc1293..27c51ce 100644
 +    if (XineramaIsActive(d)) {
 +        int number_of_monitors;
 +        XineramaScreenInfo *screen_info = XineramaQueryScreens(d, &number_of_monitors);
-+        /* Checking on which monitor the origin of the window is. Technically it
-+         * would be better to check for the center of the window, but that is
-+         * only relevant in the edge case when a window is displayed on multiple
-+         * outputs simultaneously.
-+         */
 +        for (int i = 0; i < number_of_monitors; i++) {
-+            if (coords_in_box(cur->wx, cur->wy,
++            if (coords_in_box(cur->wx + (cur->ww / 2), cur->wy + (cur->wh / 2),
 +                screen_info[i].x_org, screen_info[i].y_org,
 +                screen_info[i].width, screen_info[i].height))
 +                XMoveWindow(d, cur->w,
@@ -90,7 +85,7 @@ index 0cc1293..27c51ce 100644
 +            int number_of_monitors;
 +            XineramaScreenInfo *screen_info = XineramaQueryScreens(d, &number_of_monitors);
 +            for (int i = 0; i < number_of_monitors; i++) {
-+                if (coords_in_box(cur->wx, cur->wy,
++                if (coords_in_box(cur->wx + (cur->ww / 2), cur->wy + (cur->wh / 2),
 +                    screen_info[i].x_org, screen_info[i].y_org,
 +                    screen_info[i].width, screen_info[i].height))
 +                    XMoveResizeWindow(d, cur->w,

--- a/patches/sowm-primitive-multimonitor.patch
+++ b/patches/sowm-primitive-multimonitor.patch
@@ -13,7 +13,7 @@ diff --git a/sowm.c b/sowm.c
 index 0cc1293..27c51ce 100644
 --- a/sowm.c
 +++ b/sowm.c
-@@ -4,9 +4,11 @@
+@@ -4,9 +4,10 @@
  #include <X11/XF86keysym.h>
  #include <X11/keysym.h>
  #include <X11/XKBlib.h>
@@ -21,7 +21,6 @@ index 0cc1293..27c51ce 100644
  #include <stdlib.h>
  #include <signal.h>
  #include <unistd.h>
-+#include <stdbool.h>
  
  typedef union {
      const char** com;
@@ -45,11 +44,11 @@ index 0cc1293..27c51ce 100644
      if (cur) XKillClient(d, cur->w);
  }
  
-+bool coords_in_box (int x, int y, int box_x, int box_y, int box_w, int box_h) {
++int coords_in_box (int x, int y, int box_x, int box_y, int box_w, int box_h) {
 +    if ((x >= box_x && x < box_x + box_w) && (y >= box_y && y < box_y + box_h))
-+        return true;
++        return 1;
 +    else
-+        return false;
++        return 0;
 +}
 +
  void win_center() {

--- a/patches/sowm-primitive-multimonitor.patch
+++ b/patches/sowm-primitive-multimonitor.patch
@@ -10,7 +10,7 @@ index 8573837..72e9542 100644
  PREFIX?= /usr
  BINDIR?= $(PREFIX)/bin
 diff --git a/sowm.c b/sowm.c
-index 0cc1293..40b39dd 100644
+index 0cc1293..665b0f8 100644
 --- a/sowm.c
 +++ b/sowm.c
 @@ -4,6 +4,7 @@
@@ -38,21 +38,16 @@ index 0cc1293..40b39dd 100644
  }
  
  void key_press(XEvent *e) {
-@@ -172,12 +174,41 @@ void win_kill() {
+@@ -172,12 +174,36 @@ void win_kill() {
      if (cur) XKillClient(d, cur->w);
  }
  
-+int coords_in_box (int x, int y, int box_x, int box_y, int box_w, int box_h) {
-+    return ((x >= box_x && x < box_x + box_w) && (y >= box_y && y < box_y + box_h));
-+}
-+
 +int multimonitor_center_fs (int fs) {
 +    if (XineramaIsActive(d)) {
 +        XineramaScreenInfo *screen_info = XineramaQueryScreens(d, &monitors);
 +        for (int i = 0; i < monitors; i++) {
-+            if (coords_in_box(cur->wx + (cur->ww / 2), cur->wy + (cur->wh / 2),
-+                screen_info[i].x_org, screen_info[i].y_org,
-+                screen_info[i].width, screen_info[i].height)) {
++            if ((cur->wx >= screen_info[i].x_org && cur->wx < screen_info[i].x_org + screen_info[i].width)
++                && (cur->wy >= screen_info[i].y_org && cur->wy < screen_info[i].y_org + screen_info[i].height)) {
 +                if (fs)
 +                    XMoveResizeWindow(d, cur->w,
 +                                      screen_info[i].x_org, screen_info[i].y_org,
@@ -81,7 +76,7 @@ index 0cc1293..40b39dd 100644
  }
  
  void win_fs() {
-@@ -185,8 +216,8 @@ void win_fs() {
+@@ -185,8 +211,8 @@ void win_fs() {
  
      if ((cur->f = cur->f ? 0 : 1)) {
          win_size(cur->w, &cur->wx, &cur->wy, &cur->ww, &cur->wh);

--- a/patches/sowm-primitive-multimonitor.patch
+++ b/patches/sowm-primitive-multimonitor.patch
@@ -10,10 +10,10 @@ index 8573837..72e9542 100644
  PREFIX?= /usr
  BINDIR?= $(PREFIX)/bin
 diff --git a/sowm.c b/sowm.c
-index 0cc1293..27c51ce 100644
+index 0cc1293..ead3f6c 100644
 --- a/sowm.c
 +++ b/sowm.c
-@@ -4,9 +4,10 @@
+@@ -4,6 +4,7 @@
  #include <X11/XF86keysym.h>
  #include <X11/keysym.h>
  #include <X11/XKBlib.h>
@@ -21,10 +21,16 @@ index 0cc1293..27c51ce 100644
  #include <stdlib.h>
  #include <signal.h>
  #include <unistd.h>
+@@ -48,7 +49,7 @@ static void ws_go(const Arg arg);
+ static int  xerror() { return 0;}
  
- typedef union {
-     const char** com;
-@@ -97,6 +99,7 @@ void notify_enter(XEvent *e) {
+ static client       *list = {0}, *ws_list[10] = {0}, *cur;
+-static int          ws = 1, sw, sh, wx, wy;
++static int          ws = 1, sw, sh, wx, wy, monitors;
+ static unsigned int ww, wh;
+ 
+ static Display      *d;
+@@ -97,6 +98,7 @@ void notify_enter(XEvent *e) {
  
  void notify_motion(XEvent *e) {
      if (!mouse.subwindow) return;
@@ -32,7 +38,7 @@ index 0cc1293..27c51ce 100644
  
      while(XCheckTypedEvent(d, MotionNotify, e));
  
-@@ -108,6 +111,7 @@ void notify_motion(XEvent *e) {
+@@ -108,6 +110,7 @@ void notify_motion(XEvent *e) {
          wy + (mouse.button == 1 ? yd : 0),
          ww + (mouse.button == 3 ? xd : 0),
          wh + (mouse.button == 3 ? yd : 0));
@@ -40,7 +46,7 @@ index 0cc1293..27c51ce 100644
  }
  
  void key_press(XEvent *e) {
-@@ -172,12 +171,29 @@ void win_kill() {
+@@ -172,12 +175,28 @@ void win_kill() {
      if (cur) XKillClient(d, cur->w);
  }
  
@@ -55,9 +61,8 @@ index 0cc1293..27c51ce 100644
  
 -    XMoveWindow(d, cur->w, (sw - ww) / 2, (sh - wh) / 2);
 +    if (XineramaIsActive(d)) {
-+        int number_of_monitors;
-+        XineramaScreenInfo *screen_info = XineramaQueryScreens(d, &number_of_monitors);
-+        for (int i = 0; i < number_of_monitors; i++) {
++        XineramaScreenInfo *screen_info = XineramaQueryScreens(d, &monitors);
++        for (int i = 0; i < monitors; i++) {
 +            if (coords_in_box(cur->wx + (cur->ww / 2), cur->wy + (cur->wh / 2),
 +                screen_info[i].x_org, screen_info[i].y_org,
 +                screen_info[i].width, screen_info[i].height))
@@ -71,16 +76,15 @@ index 0cc1293..27c51ce 100644
  }
  
  void win_fs() {
-@@ -185,8 +214,19 @@ void win_fs() {
+@@ -185,8 +204,18 @@ void win_fs() {
  
      if ((cur->f = cur->f ? 0 : 1)) {
          win_size(cur->w, &cur->wx, &cur->wy, &cur->ww, &cur->wh);
 -        XMoveResizeWindow(d, cur->w, 0, 0, sw, sh);
 -
 +        if (XineramaIsActive(d)) {
-+            int number_of_monitors;
-+            XineramaScreenInfo *screen_info = XineramaQueryScreens(d, &number_of_monitors);
-+            for (int i = 0; i < number_of_monitors; i++) {
++            XineramaScreenInfo *screen_info = XineramaQueryScreens(d, &monitors);
++            for (int i = 0; i < monitors; i++) {
 +                if (coords_in_box(cur->wx + (cur->ww / 2), cur->wy + (cur->wh / 2),
 +                    screen_info[i].x_org, screen_info[i].y_org,
 +                    screen_info[i].width, screen_info[i].height))

--- a/patches/sowm-primitive-multimonitor.patch
+++ b/patches/sowm-primitive-multimonitor.patch
@@ -10,7 +10,7 @@ index 8573837..72e9542 100644
  PREFIX?= /usr
  BINDIR?= $(PREFIX)/bin
 diff --git a/sowm.c b/sowm.c
-index 0cc1293..fa911b0 100644
+index 0cc1293..e8cbce6 100644
 --- a/sowm.c
 +++ b/sowm.c
 @@ -4,6 +4,7 @@
@@ -38,13 +38,12 @@ index 0cc1293..fa911b0 100644
  }
  
  void key_press(XEvent *e) {
-@@ -172,12 +174,35 @@ void win_kill() {
+@@ -172,12 +174,34 @@ void win_kill() {
      if (cur) XKillClient(d, cur->w);
  }
  
 +int multimonitor_center_fs (int fs) {
-+    if (!XineramaIsActive(d))
-+        return 1;
++    if (!XineramaIsActive(d)) return 1;
 +    XineramaScreenInfo *screen_info = XineramaQueryScreens(d, &monitors);
 +    for (int i = 0; i < monitors; i++) {
 +        if ((cur->wx >= screen_info[i].x_org && cur->wx < screen_info[i].x_org + screen_info[i].width)
@@ -75,7 +74,7 @@ index 0cc1293..fa911b0 100644
  }
  
  void win_fs() {
-@@ -185,8 +210,8 @@ void win_fs() {
+@@ -185,8 +209,8 @@ void win_fs() {
  
      if ((cur->f = cur->f ? 0 : 1)) {
          win_size(cur->w, &cur->wx, &cur->wy, &cur->ww, &cur->wh);


### PR DESCRIPTION
With this patch, center and fullscreen will work as expected when using
multiple outputs. (See Issue #19)

As the title states, the patch is primitive: Whenever the user tries to fullscreen or center a window, Xinerama is queried for a list of all monitors and a loop will iterate over the list, checking on which monitor the origin of the window (x and y coordinates) is. This has a minor edge case: When a windows origin is not on a monitor (as an example, if the user moved the window partly off the screen on the left side), it will neither fullscreen nor center.