### PR TITLE
New Patch: Rectangular style window launcher/mover + README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ An itsy bitsy floating window manager (*220~ sloc / 24kb compiled!*).
 3) Copy it to your path or run `make install`.
     - `DESTDIR` and `PREFIX` are supported.
 
+4) (Optional) Apply patch with `git apply patches/patch-name`
+
 
 ## Thanks
 

--- a/patches/sowm-rect-to-move.patch
+++ b/patches/sowm-rect-to-move.patch
@@ -1,0 +1,116 @@
+diff --git a/sowm.c b/sowm.c
+index bc14c4e..83ed0fb 100644
+--- a/sowm.c
++++ b/sowm.c
+@@ -65,6 +65,9 @@ static void (*events[LASTEvent])(XEvent *e) = {
+     [MotionNotify]     = notify_motion
+ };
+ 
++
++Window WaitingWindow;
++
+ #include "config.h"
+ 
+ #define win        (client *t=0, *c=list; c && t!=list->prev; t=c, c=c->next)
+@@ -75,6 +78,23 @@ static void (*events[LASTEvent])(XEvent *e) = {
+     XGetGeometry(d, W, &(Window){0}, gx, gy, gw, gh, \
+                  &(unsigned int){0}, &(unsigned int){0})
+ 
++#define abs(a) a < 0 ? -a : a
++
++void draw_outline(int x1, int y1, int x2, int y2) {
++    XClearWindow(d, RootWindow(d, DefaultScreen(d)));
++
++    GC gc = XCreateGC(d, RootWindow(d, DefaultScreen(d)), 0, NULL);
++    if(!gc)return;
++
++    XSetForeground(d, gc, WhitePixel(d, DefaultScreen(d)));
++    XDrawLine(d, RootWindow(d, DefaultScreen(d)), gc, x1, y1, x1, y2);
++    XDrawLine(d, RootWindow(d, DefaultScreen(d)), gc, x1, y1, x2, y1);
++    XDrawLine(d, RootWindow(d, DefaultScreen(d)), gc, x1, y2, x2, y2);
++    XDrawLine(d, RootWindow(d, DefaultScreen(d)), gc, x2, y1, x2, y2);
++    XFreeGC(d, gc);
++    XFlush(d);
++}
++
+ void win_focus(client *c) {
+     cur = c;
+     XSetInputFocus(d, cur->w, RevertToParent, CurrentTime);
+@@ -93,7 +113,10 @@ void notify_enter(XEvent *e) {
+ }
+ 
+ void notify_motion(XEvent *e) {
+-    if (!mouse.subwindow || cur->f) return;
++    if (!mouse.subwindow || cur->f) {
++        draw_outline(mouse.x_root, mouse.y_root, e->xbutton.x_root, e->xbutton.y_root);
++        return;
++    }
+ 
+     while(XCheckTypedEvent(d, MotionNotify, e));
+ 
+@@ -116,15 +139,42 @@ void key_press(XEvent *e) {
+ }
+ 
+ void button_press(XEvent *e) {
+-    if (!e->xbutton.subwindow) return;
++    mouse = e->xbutton;
+ 
++    if (!e->xbutton.subwindow) return;
+     win_size(e->xbutton.subwindow, &wx, &wy, &ww, &wh);
+     XRaiseWindow(d, e->xbutton.subwindow);
+-    mouse = e->xbutton;
+ }
+ 
+-void button_release() {
+-    mouse.subwindow = 0;
++void button_release(XEvent *e) {
++    XClearWindow(d, RootWindow(d, DefaultScreen(d)));
++
++    if(WaitingWindow){
++        XSelectInput(d, WaitingWindow, StructureNotifyMask|EnterWindowMask);
++        win_size(WaitingWindow, &wx, &wy, &ww, &wh);
++        win_add(WaitingWindow);
++        cur = list->prev;
++
++        XMoveResizeWindow(d, cur->w,
++            mouse.x_root,
++            mouse.y_root,
++            abs(e->xbutton.x_root - mouse.x_root),
++            abs(e->xbutton.y_root - mouse.y_root));
++
++        XMapWindow(d, WaitingWindow);
++        win_focus(list->prev);
++
++        WaitingWindow = 0;
++
++    } else if(!mouse.subwindow && cur) {
++        XMoveResizeWindow(d, cur->w,
++            mouse.x_root,
++            mouse.y_root,
++            abs(e->xbutton.x_root - mouse.x_root),
++            abs(e->xbutton.y_root - mouse.y_root));
++
++        mouse.subwindow = 0;
++    }
+ }
+ 
+ void win_add(Window w) {
+@@ -244,17 +294,7 @@ void configure_request(XEvent *e) {
+ }
+ 
+ void map_request(XEvent *e) {
+-    Window w = e->xmaprequest.window;
+-
+-    XSelectInput(d, w, StructureNotifyMask|EnterWindowMask);
+-    win_size(w, &wx, &wy, &ww, &wh);
+-    win_add(w);
+-    cur = list->prev;
+-
+-    if (wx + wy == 0) win_center();
+-
+-    XMapWindow(d, w);
+-    win_focus(list->prev);
++    WaitingWindow = e->xmaprequest.window;
+ }
+ 
+ void run(const Arg arg) {


### PR DESCRIPTION
I've added new patch that allows user to use rectangular style window launching/moving. I'm not sure that this actually called, but here's a [demonstration](https://www.reddit.com/r/unixporn/comments/eah3ak/oc_ive_wrote_sowm_patch_for_rectangle_style/). This patch does not remove original way of window dragging and resizing, It only adds the feature.

I've also added 4th step to Installation section in README.md since I've seen some reddit comments where people don't know how to apply patches.