### PR TITLE
Fix: issue #42: Workspaces(Shiftmask) + Scary warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS+= -std=c99 -Wall -Wextra -Wmissing-prototypes -pedantic
+CFLAGS+= -std=c99 -Wall -Wextra -pedantic
 LDADD+= -lX11
 LDFLAGS=
 PREFIX?= /usr

--- a/sowm.c
+++ b/sowm.c
@@ -49,7 +49,7 @@ static void ws_go(const Arg arg);
 static int  xerror() { return 0;}
 
 static client       *list = {0}, *ws_list[10] = {0}, *cur;
-static int          ws = 1, sw, sh, wx, wy, numlock;
+static int          ws = 1, sw, sh, wx, wy;
 static unsigned int ww, wh;
 
 static Display      *d;
@@ -71,7 +71,6 @@ static void (*events[LASTEvent])(XEvent *e) = {
 #define win        (client *t=0, *c=list; c && t!=list->prev; t=c, c=c->next)
 #define ws_save(W) ws_list[W] = list
 #define ws_sel(W)  list = ws_list[ws = W]
-#define mask(M)    (M & ~(numlock | LockMask))
 
 #define win_size(W, gx, gy, gw, gh) \
     XGetGeometry(d, W, &(Window){0}, gx, gy, gw, gh, \
@@ -112,13 +111,10 @@ void notify_motion(XEvent *e) {
 void key_press(XEvent *e) {
     KeySym keysym = XkbKeycodeToKeysym(d, e->xkey.keycode, 0, 0);
 
-    for (unsigned int i=0; i < sizeof(keys)/sizeof(*keys); ++i) {
-        numlock = ((e->xkey.state & keys[i].mod) == keys[i].mod);
-
-        if (mask(keys[i].mod) == mask(e->xkey.state) &&
+    for (unsigned int i=0; i < sizeof(keys)/sizeof(*keys); ++i)
+        if (keys[i].mod == e->xkey.state &&
             keys[i].keysym == keysym)
             keys[i].function(keys[i].arg);
-    }
 }
 
 void button_press(XEvent *e) {


### PR DESCRIPTION
I just removed the numlock check since it doesn't work as intended while working just fine without it.
Let me know if the part that I removed has important role, so that I could add back :) What I concluded-from various sources like dwm-is: it's used for double checking if user has capslock/numlock on, but it will work just fine without it. 
For Makefile, simply removing ```-Wmissing-prototypes``` will removes that perfectly safe prototype errors.