### PR TITLE
sowm: titlebars

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -2,6 +2,8 @@
 #define CONFIG_H
 
 #define MOD Mod4Mask
+#define TH  90
+#define TC  255 + (255<<8) + (255<<16)
 
 const char* menu[]    = {"dmenu_run",      0};
 const char* term[]    = {"st",             0};

--- a/sowm.c
+++ b/sowm.c
@@ -1,12 +1,14 @@
 // sowm - An itsy bitsy floating window manager.
 
 #include <X11/Xlib.h>
+#include <X11/Xutil.h>
 #include <X11/XF86keysym.h>
 #include <X11/keysym.h>
 #include <X11/XKBlib.h>
 #include <stdlib.h>
 #include <signal.h>
 #include <unistd.h>
+#include <string.h>
 
 #include "sowm.h"
 
@@ -31,6 +33,27 @@ static void (*events[LASTEvent])(XEvent *e) = {
 
 #include "config.h"
 
+void title_add(client *c) {
+    if (c->t) return;
+
+    XClassHint cl;
+    XGetClassHint(d, c->w, &cl);
+
+    if (!strcmp(cl.res_name, "no-title")) return;
+
+    win_size(c->w, &wx, &wy, &ww, &wh);
+    c->t = XCreateSimpleWindow(d, root, wx, wy - TH, ww, TH, 0, TC, TC);
+    XMapWindow(d, c->t);
+}
+
+void title_del(client *c) {
+    if (!c->t) return;
+
+    XUnmapWindow(d, c->t);
+    XDestroyWindow(d, c->t);
+    c->t = 0;
+}
+
 void win_focus(client *c) {
     cur = c;
     XSetInputFocus(d, cur->w, RevertToParent, CurrentTime);
@@ -51,6 +74,11 @@ void notify_enter(XEvent *e) {
 void notify_motion(XEvent *e) {
     if (!mouse.subwindow || cur->f) return;
 
+    if (mouse.subwindow == cur->t) {
+        mouse.subwindow = cur->w;
+        win_size(cur->w, &wx, &wy, &ww, &wh);
+    }
+
     while(XCheckTypedEvent(d, MotionNotify, e));
 
     int xd = e->xbutton.x_root - mouse.x_root;
@@ -61,6 +89,11 @@ void notify_motion(XEvent *e) {
         wy + (mouse.button == 1 ? yd : 0),
         MAX(1, ww + (mouse.button == 3 ? xd : 0)),
         MAX(1, wh + (mouse.button == 3 ? yd : 0)));
+
+    if (cur->t) XMoveResizeWindow(d, cur->t,
+        wx + (mouse.button == 1 ? xd : 0),
+        wy + (mouse.button == 1 ? yd : 0) - TH,
+        MAX(1, ww + (mouse.button == 3 ? xd : 0)), TH);
 }
 
 void key_press(XEvent *e) {
@@ -117,6 +150,7 @@ void win_del(Window w) {
     if (x->next)      x->next->prev = x->prev;
     if (x->prev)      x->prev->next = x->next;
 
+    title_del(x);
     free(x);
     ws_save(ws);
 }
@@ -130,6 +164,8 @@ void win_center(const Arg arg) {
 
     win_size(cur->w, &(int){0}, &(int){0}, &ww, &wh);
     XMoveWindow(d, cur->w, (sw - ww) / 2, (sh - wh) / 2);
+
+    if (cur->t) XMoveWindow(d, cur->t, (sw - ww) / 2, (sh - wh - TH * 2) / 2);
 }
 
 void win_fs(const Arg arg) {
@@ -138,9 +174,12 @@ void win_fs(const Arg arg) {
     if ((cur->f = cur->f ? 0 : 1)) {
         win_size(cur->w, &cur->wx, &cur->wy, &cur->ww, &cur->wh);
         XMoveResizeWindow(d, cur->w, 0, 0, sw, sh);
+        XRaiseWindow(d, cur->w);
+        title_del(cur);
 
     } else {
         XMoveResizeWindow(d, cur->w, cur->wx, cur->wy, cur->ww, cur->wh);
+        title_add(cur);
     }
 }
 
@@ -156,6 +195,7 @@ void win_to_ws(const Arg arg) {
     ws_sel(tmp);
     win_del(cur->w);
     XUnmapWindow(d, cur->w);
+    title_del(cur);
     ws_save(tmp);
 
     if (list) win_focus(list);
@@ -165,6 +205,10 @@ void win_prev(const Arg arg) {
     if (!cur) return;
 
     XRaiseWindow(d, cur->prev->w);
+
+    if (cur->prev->t)
+        XRaiseWindow(d, cur->prev->t);
+
     win_focus(cur->prev);
 }
 
@@ -172,6 +216,10 @@ void win_next(const Arg arg) {
     if (!cur) return;
 
     XRaiseWindow(d, cur->next->w);
+
+    if (cur->next->t)
+        XRaiseWindow(d, cur->next->t);
+
     win_focus(cur->next);
 }
 
@@ -183,11 +231,17 @@ void ws_go(const Arg arg) {
     ws_save(ws);
     ws_sel(arg.i);
 
-    for win XMapWindow(d, c->w);
+    for win {
+        XMapWindow(d, c->w);
+        title_add(c);
+    }
 
     ws_sel(tmp);
 
-    for win XUnmapWindow(d, c->w);
+    for win {
+        XUnmapWindow(d, c->w);
+        title_del(c);
+    }
 
     ws_sel(arg.i);
 
@@ -219,6 +273,7 @@ void map_request(XEvent *e) {
 
     XMapWindow(d, w);
     win_focus(list->prev);
+    title_add(cur);
 }
 
 void run(const Arg arg) {

--- a/sowm.h
+++ b/sowm.h
@@ -30,7 +30,7 @@ typedef struct client {
     struct client *next, *prev;
     int f, wx, wy;
     unsigned int ww, wh;
-    Window w;
+    Window w, t;
 } client;
 
 void button_press(XEvent *e);
@@ -43,6 +43,8 @@ void notify_destroy(XEvent *e);
 void notify_enter(XEvent *e);
 void notify_motion(XEvent *e);
 void run(const Arg arg);
+void title_add(client *c);
+void title_del(client *c);
 void win_add(Window w);
 void win_center(const Arg arg);
 void win_del(Window w);


### PR DESCRIPTION
```
* Added simple, single color, titlebars.

  - Windows can be excluded from decoration by having 
    their class set to 'no-title'.
```

**NOTE**: All future patches shall be done in this way. Keep a Pull Request open for eternity, GitHub will let you know if there are merge conflicts. Appending `.patch` allows you to obtain a downloadable patch file. You can also use `git` to merge these into your own fork.

Far easier to maintain, each patch has a set author, etc etc.

Patch: https://patch-diff.githubusercontent.com/raw/dylanaraps/sowm/pull/57.patch