### PR TITLE
sowm: add Multihead fullscreen support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ config.h:
 	cp config.def.h config.h
 
 sowm:
-	$(CC) -O3 $(CFLAGS) -o sowm sowm.c -lX11 $(LDFLAGS)
+	$(CC) -O3 $(CFLAGS) -o sowm sowm.c -lX11 -lXinerama $(LDFLAGS)
 
 install: all
 	install -Dm755 sowm $(DESTDIR)$(BINDIR)/sowm

--- a/sowm.c
+++ b/sowm.c
@@ -4,6 +4,7 @@
 #include <X11/XF86keysym.h>
 #include <X11/keysym.h>
 #include <X11/XKBlib.h>
+#include <X11/extensions/Xinerama.h>
 #include <stdlib.h>
 #include <signal.h>
 #include <unistd.h>
@@ -11,7 +12,7 @@
 #include "sowm.h"
 
 static client       *list = {0}, *ws_list[10] = {0}, *cur;
-static int          ws = 1, sw, sh, wx, wy, numlock = 0;
+static int          ws = 1, sw, sh, wx, wy, numlock = 0, monitors;
 static unsigned int ww, wh;
 
 static Display      *d;
@@ -62,6 +63,8 @@ void notify_motion(XEvent *e) {
         wy + (mouse.button == 1 ? yd : 0),
         MAX(1, ww + (mouse.button == 3 ? xd : 0)),
         MAX(1, wh + (mouse.button == 3 ? yd : 0)));
+
+    win_size(cur->w, &cur->wx, &cur->wx, &cur->ww, &cur->wh);
 }
 
 void key_press(XEvent *e) {
@@ -126,11 +129,37 @@ void win_kill(const Arg arg) {
     if (cur) XKillClient(d, cur->w);
 }
 
+int multimonitor_action (int action) { // action = 0 -> center; action = 1 -> fs
+    if (!XineramaIsActive(d)) return 1;
+    XineramaScreenInfo *si = XineramaQueryScreens(d, &monitors);
+    for (int i = 0; i < monitors; i++) {
+        if ((cur->wx + (cur->ww/2) >= (unsigned int)si[i].x_org
+                && cur->wx + (cur->ww/2) < (unsigned int)si[i].x_org + si[i].width)
+            && ( cur->wy + (cur->wh/2) >= (unsigned int)si[i].y_org
+                && cur->wy + (cur->wh/2) < (unsigned int)si[i].y_org + si[i].height)) {
+            if (action)
+                XMoveResizeWindow(d, cur->w,
+                                  si[i].x_org, si[i].y_org,
+                                  si[i].width, si[i].height);
+            else
+                XMoveWindow(d, cur->w,
+                            si[i].x_org + ((si[i].width - ww)/2),
+                            si[i].y_org + ((si[i].height -wh)/2));
+            break;
+        }
+    }
+    return 0;
+}
+
 void win_center(const Arg arg) {
     if (!cur) return;
 
     win_size(cur->w, &(int){0}, &(int){0}, &ww, &wh);
-    XMoveWindow(d, cur->w, (sw - ww) / 2, (sh - wh) / 2);
+    if (multimonitor_action(0)) {
+        XMoveWindow(d, cur->w, (sw - ww) / 2, (sh - wh) / 2);
+    }
+
+    win_size(cur->w, &cur->wx, &cur->wy, &cur->ww, &cur->wh);
 }
 
 void win_fs(const Arg arg) {
@@ -138,8 +167,9 @@ void win_fs(const Arg arg) {
 
     if ((cur->f = cur->f ? 0 : 1)) {
         win_size(cur->w, &cur->wx, &cur->wy, &cur->ww, &cur->wh);
-        XMoveResizeWindow(d, cur->w, 0, 0, sw, sh);
-
+        if(multimonitor_action(1)) {
+          XMoveResizeWindow(d, cur->w, 0, 0, sw, sh);
+        }
     } else {
         XMoveResizeWindow(d, cur->w, cur->wx, cur->wy, cur->ww, cur->wh);
     }

--- a/sowm.h
+++ b/sowm.h
@@ -33,6 +33,8 @@ typedef struct client {
     Window w;
 } client;
 
+int multimonitor_action(int action);
+
 void button_press(XEvent *e);
 void button_release(XEvent *e);
 void configure_request(XEvent *e);


### PR DESCRIPTION
I pulled this patch from (the old patches repo)[https://github.com/dylanaraps/sowm-patches/blob/master/patches/sowm-primitive-multimonitor.patch] and brought it up to date with master.

The end effect is that you can do centering and fullscreen on each monitor independently