### PR TITLE
Use NetBSD native sound tools

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -5,12 +5,18 @@
 
 const char* menu[]    = {"dmenu_run",      0};
 const char* term[]    = {"st",             0};
-const char* scrot[]   = {"scr",            0};
+const char* scrot[]   = {"scrot",          0};
 const char* briup[]   = {"bri", "10", "+", 0};
 const char* bridown[] = {"bri", "10", "-", 0};
+#if defined (__NetBSD__)
+const char* volup[] = {"mixerctl", "-w", "outputs.master+=5", 0};
+const char* voldown[] = {"mixerctl", "-w", "outputs.master-=5", 0};
+const char* volmute[] = {"mixerctl", "-w", "outputs.master=0", 0};
+#elif
 const char* voldown[] = {"amixer", "sset", "Master", "5%-",         0};
 const char* volup[]   = {"amixer", "sset", "Master", "5%+",         0};
 const char* volmute[] = {"amixer", "sset", "Master", "toggle",      0};
+#endif
 const char* colors[]  = {"bud", "/home/goldie/Pictures/Wallpapers", 0};
 
 static struct key keys[] = {


### PR DESCRIPTION
`sowm` is now available as a `pkgscr` package (https://pkgsrc.se/wm/sowm) for NetBSD and other systems using the `pkgsrc` infrastructure.

According to NetBSD's policy I'm providing you with the needed patch to `config.def.h` in order to use NetBSD's native sound tools. Please consider it for future releases.

Regards