### PR TITLE
sowm: Window splitting

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -17,6 +17,12 @@ static struct key keys[] = {
     {MOD,      XK_q,   win_kill,   {0}},
     {MOD,      XK_c,   win_center, {0}},
     {MOD,      XK_f,   win_fs,     {0}},
+    
+    {MOD|Mod1Mask,  XK_k,  win_half,  {.com = (const char*[]){"n"}}},
+    {MOD|Mod1Mask,  XK_j,  win_half,  {.com = (const char*[]){"s"}}},
+    {MOD|Mod1Mask,  XK_l,  win_half,  {.com = (const char*[]){"e"}}},
+    {MOD|Mod1Mask,  XK_h,  win_half,  {.com = (const char*[]){"w"}}},
+
 
     {Mod1Mask,           XK_Tab, win_next,   {0}},
     {Mod1Mask|ShiftMask, XK_Tab, win_prev,   {0}},

--- a/sowm.c
+++ b/sowm.c
@@ -31,6 +31,18 @@ static void (*events[LASTEvent])(XEvent *e) = {
 
 #include "config.h"
 
+void win_half(const Arg arg) {
+     char m = arg.com[0][0];
+
+     win_size(cur->w, &wx, &wy, &ww, &wh);
+
+     XMoveResizeWindow(d, cur->w, \
+        (m == 'w' ? wx : m == 'e' ? (wx + ww / 2) : wx),
+        (m == 'n' ? wy : m == 's' ? (wy + wh / 2) : wy),
+        (m == 'w' ? (ww / 2) : m == 'e' ? (ww / 2) : ww),
+        (m == 'n' ? (wh / 2) : m == 's' ? (wh / 2) : wh));
+}
+
 void win_focus(client *c) {
     cur = c;
     XSetInputFocus(d, cur->w, RevertToParent, CurrentTime);

--- a/sowm.h
+++ b/sowm.h
@@ -51,6 +51,7 @@ void win_focus(client *c);
 void win_kill(const Arg arg);
 void win_prev(const Arg arg);
 void win_next(const Arg arg);
+void win_half(const Arg arg);
 void win_to_ws(const Arg arg);
 void ws_go(const Arg arg);
 


### PR DESCRIPTION
```
 * Add keybinds for splitting windows
  - Use vim keybinds with Win+Alt
  - Example: Win+Alt+h will split the window to the left


  - Note: this patch will *not* snap windows to corners of the screen.


```
Patch: [https://patch-diff.githubusercontent.com/raw/dylanaraps/sowm/pull/76.patch](https://patch-diff.githubusercontent.com/raw/dylanaraps/sowm/pull/76.patch)
Requested from issue #75.