### PR TITLE
sowm: Allow custom button mapping

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -46,4 +46,21 @@ static struct key keys[] = {
     {MOD|ShiftMask, XK_6, win_to_ws, {.i = 6}},
 };
 
+static struct button buttons[] = {
+    {MOD,           Button1, win_raise, {0}},
+    {MOD,           Button1, win_move, {0}},
+
+    {MOD,           Button3, win_raise, {0}},
+    {MOD,           Button3, win_resize, {0}},
+
+    {MOD|ShiftMask, Button1, win_raise, {0}},
+    {MOD|ShiftMask, Button1, win_center, {0}},
+
+    {MOD|ShiftMask, Button3, win_raise, {0}},
+    {MOD|ShiftMask, Button3, win_fs, {0}},
+
+    {MOD,           Button2, win_lower, {0}},
+    {MOD|ShiftMask, Button2, win_kill, {0}},
+};
+
 #endif

--- a/sowm.c
+++ b/sowm.c
@@ -75,13 +75,13 @@ void key_press(XEvent *e) {
 }
 
 void win_move(const Arg arg) {
-	win_size(mouse.subwindow, &wx, &wy, &ww, &wh);
-	drag = MOVING;
+    win_size(mouse.subwindow, &wx, &wy, &ww, &wh);
+    drag = MOVING;
 }
 
 void win_resize(const Arg arg) {
-	win_size(mouse.subwindow, &wx, &wy, &ww, &wh);
-	drag = SIZING;
+    win_size(mouse.subwindow, &wx, &wy, &ww, &wh);
+    drag = SIZING;
 }
 
 void button_press(XEvent *e) {
@@ -149,15 +149,15 @@ void win_center(const Arg arg) {
 }
 
 void win_lower(const Arg arg) {
-	if (!cur) return;
+    if (!cur) return;
 
-	XLowerWindow(d, cur->w);
+    XLowerWindow(d, cur->w);
 }
 
 void win_raise(const Arg arg) {
-	if (!cur) return;
+    if (!cur) return;
 
-	XRaiseWindow(d, cur->w);
+    XRaiseWindow(d, cur->w);
 }
 
 void win_fs(const Arg arg) {

--- a/sowm.c
+++ b/sowm.c
@@ -16,6 +16,7 @@ static unsigned int ww, wh;
 
 static Display      *d;
 static XButtonEvent mouse;
+enum { MOVING = 1, SIZING = 2 } drag;
 static Window       root;
 
 static void (*events[LASTEvent])(XEvent *e) = {
@@ -50,7 +51,7 @@ void notify_enter(XEvent *e) {
 }
 
 void notify_motion(XEvent *e) {
-    if (!mouse.subwindow || cur->f) return;
+    if (!mouse.subwindow || !drag || cur->f) return;
 
     while(XCheckTypedEvent(d, MotionNotify, e));
 
@@ -58,10 +59,10 @@ void notify_motion(XEvent *e) {
     int yd = e->xbutton.y_root - mouse.y_root;
 
     XMoveResizeWindow(d, mouse.subwindow,
-        wx + (mouse.button == 1 ? xd : 0),
-        wy + (mouse.button == 1 ? yd : 0),
-        MAX(1, ww + (mouse.button == 3 ? xd : 0)),
-        MAX(1, wh + (mouse.button == 3 ? yd : 0)));
+        wx + (drag == MOVING ? xd : 0),
+        wy + (drag == MOVING ? yd : 0),
+        MAX(1, ww + (drag == SIZING ? xd : 0)),
+        MAX(1, wh + (drag == SIZING ? yd : 0)));
 }
 
 void key_press(XEvent *e) {
@@ -73,12 +74,26 @@ void key_press(XEvent *e) {
             keys[i].function(keys[i].arg);
 }
 
+void win_move(const Arg arg) {
+	win_size(mouse.subwindow, &wx, &wy, &ww, &wh);
+	drag = MOVING;
+}
+
+void win_resize(const Arg arg) {
+	win_size(mouse.subwindow, &wx, &wy, &ww, &wh);
+	drag = SIZING;
+}
+
 void button_press(XEvent *e) {
     if (!e->xbutton.subwindow) return;
+    unsigned mod = mod_clean(e->xbutton.state);
 
-    win_size(e->xbutton.subwindow, &wx, &wy, &ww, &wh);
-    XRaiseWindow(d, e->xbutton.subwindow);
     mouse = e->xbutton;
+    drag = 0;
+    for (unsigned int i = 0; i < sizeof(buttons)/sizeof(*buttons); ++i)
+        if (buttons[i].button == e->xbutton.button &&
+            mod_clean(buttons[i].mod) == mod)
+            buttons[i].function(buttons[i].arg);
 }
 
 void button_release(XEvent *e) {
@@ -131,6 +146,18 @@ void win_center(const Arg arg) {
 
     win_size(cur->w, &(int){0}, &(int){0}, &ww, &wh);
     XMoveWindow(d, cur->w, (sw - ww) / 2, (sh - wh) / 2);
+}
+
+void win_lower(const Arg arg) {
+	if (!cur) return;
+
+	XLowerWindow(d, cur->w);
+}
+
+void win_raise(const Arg arg) {
+	if (!cur) return;
+
+	XRaiseWindow(d, cur->w);
 }
 
 void win_fs(const Arg arg) {
@@ -258,9 +285,9 @@ void input_grab(Window root) {
                 XGrabKey(d, code, keys[i].mod | modifiers[j], root,
                         True, GrabModeAsync, GrabModeAsync);
 
-    for (i = 1; i < 4; i += 2)
-        for (j = 0; j < sizeof(modifiers)/sizeof(*modifiers); j++)
-            XGrabButton(d, i, MOD | modifiers[j], root, True,
+    for (i = 0; i < sizeof(buttons)/sizeof(*buttons); i++)
+        for (size_t j = 0; j < sizeof(modifiers)/sizeof(*modifiers); j++)
+            XGrabButton(d, buttons[i].button, buttons[i].mod | modifiers[j], root, True,
                 ButtonPressMask|ButtonReleaseMask|PointerMotionMask,
                 GrabModeAsync, GrabModeAsync, 0, 0);
 

--- a/sowm.h
+++ b/sowm.h
@@ -26,6 +26,13 @@ struct key {
     const Arg arg;
 };
 
+struct button {
+	unsigned int mod;
+	unsigned int button;
+	void (*function)(const Arg arg);
+	const Arg arg;
+};
+
 typedef struct client {
     struct client *next, *prev;
     int f, wx, wy;
@@ -50,6 +57,10 @@ void win_del(Window w);
 void win_fs(const Arg arg);
 void win_focus(client *c);
 void win_kill(const Arg arg);
+void win_lower(const Arg arg);
+void win_raise(const Arg arg);
+void win_move(const Arg arg);
+void win_resize(const Arg arg);
 void win_prev(const Arg arg);
 void win_next(const Arg arg);
 void win_to_ws(const Arg arg);


### PR DESCRIPTION
This patch introduces custom button (pointer / mouse) mapping functionality. `config.def.h` has the default mappings for MOD+Button1 (new function: `win_move`) and MOD+Button3 (new function: `win_resize`) and four new mappings:

MOD+Button2 lowers the window (new function: `win_lower`)
MOD+Shift+Button1 centers the window (`win_center`)
MOD+Shift+Button2 kills the window (`win_kill`)
MOD+Shift+Button3 makes the window full-screen (`win_fs`)

Note that raising the window is a separate function (new function: `win_raise`) which doesn't necessarily need to be attached to an operation. For example, you could have a mapping to move a window without raising it.

Mappings for other mouse buttons (Button4, etc) are also possible and can use any existing function, e.g. `run` to run a command.

Patch: https://patch-diff.githubusercontent.com/raw/dylanaraps/sowm/pull/84.patch