### PR TITLE
sowm: fix Makefile dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ PREFIX ?= /usr
 BINDIR ?= $(PREFIX)/bin
 CC     ?= gcc
 
-all: config.h sowm
+all: sowm
 
 config.h:
 	cp config.def.h config.h
 
-sowm:
-	$(CC) -O3 $(CFLAGS) -o sowm sowm.c -lX11 $(LDFLAGS)
+sowm: sowm.c sowm.h config.h Makefile
+	$(CC) -O3 $(CFLAGS) -o $@ $< -lX11 $(LDFLAGS)
 
 install: all
 	install -Dm755 sowm $(DESTDIR)$(BINDIR)/sowm
@@ -20,3 +20,5 @@ uninstall:
 
 clean:
 	rm -f sowm *.o
+
+.PHONY: all install uninstall clean


### PR DESCRIPTION
So the binary no longer need to be deleted for a recompilation.