### PR TITLE
Refresh keyboard mapping uppon MappingNotify event

### DIFF
--- a/sowm.h
+++ b/sowm.h
@@ -39,6 +39,7 @@ void configure_request(XEvent *e);
 void input_grab(Window root);
 void key_press(XEvent *e);
 void map_request(XEvent *e);
+void mapping_notify(XEvent *e);
 void notify_destroy(XEvent *e);
 void notify_enter(XEvent *e);
 void notify_motion(XEvent *e);


### PR DESCRIPTION
When dynamically switching between layout the keys that are grabbed need
to also be refreshed. This is a fix similar to venam/2bwm@148d832

fixes dylanaraps#100