### PR TITLE
sowm: Autostart

### DIFF
--- a/sowm.c
+++ b/sowm.c
@@ -239,6 +239,11 @@ void run(const Arg arg) {
     execvp((char*)arg.com[0], (char**)arg.com);
 }
 
+void runAutoStart(void) {
+    system("cd ~/.sowm; ./autostart_blocking.sh");
+    system("cd ~/.sowm; ./autostart.sh &");
+}
+
 void input_grab(Window root) {
     unsigned int i, j, modifiers[] = {0, LockMask, numlock, numlock|LockMask};
     XModifierKeymap *modmap = XGetModifierMapping(d);
@@ -283,6 +288,7 @@ int main(void) {
     XSelectInput(d,  root, SubstructureRedirectMask);
     XDefineCursor(d, root, XCreateFontCursor(d, 68));
     input_grab(root);
+    runAutoStart();
 
     while (1 && !XNextEvent(d, &ev)) // 1 && will forever be here.
         if (events[ev.type]) events[ev.type](&ev);

--- a/sowm.h
+++ b/sowm.h
@@ -44,6 +44,7 @@ void notify_destroy(XEvent *e);
 void notify_enter(XEvent *e);
 void notify_motion(XEvent *e);
 void run(const Arg arg);
+void runAutoStart(void);
 void win_add(Window w);
 void win_center(const Arg arg);
 void win_del(Window w);


### PR DESCRIPTION
This patch runs `autostart_blocking.sh` and `autostart.sh` under the `~/.sowm` directory after sowm starts. One or both of these files ommited.

Patch link: https://patch-diff.githubusercontent.com/raw/dylanaraps/sowm/pull/106.patch

<details>
<summary> How to apply patch</summary>
Just do 
<pre>
cd sowm
git apply /path/to/105.patch
</pre>
</details