### PR TITLE
Window borders with focus + fullscreen no borders

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -4,8 +4,7 @@
 #define MOD Mod4Mask
 #define BORDER_SELECT   "#880000"
 #define BORDER_NORMAL   "#333333"
-#define BORDER_NONE     "#000000"
-#define BORDER_WIDTH    2
+#define BORDER_WIDTH    1
 
 const char* menu[]    = {"dmenu_run",      0};
 const char* term[]    = {"st",             0};

--- a/config.def.h
+++ b/config.def.h
@@ -2,6 +2,10 @@
 #define CONFIG_H
 
 #define MOD Mod4Mask
+#define BORDER_SELECT   "#880000"
+#define BORDER_NORMAL   "#333333"
+#define BORDER_NONE     "#000000"
+#define BORDER_WIDTH    2
 
 const char* menu[]    = {"dmenu_run",      0};
 const char* term[]    = {"st",             0};
@@ -11,7 +15,6 @@ const char* bridown[] = {"bri", "10", "-", 0};
 const char* voldown[] = {"amixer", "sset", "Master", "5%-",         0};
 const char* volup[]   = {"amixer", "sset", "Master", "5%+",         0};
 const char* volmute[] = {"amixer", "sset", "Master", "toggle",      0};
-const char* colors[]  = {"bud", "/home/goldie/Pictures/Wallpapers", 0};
 
 static struct key keys[] = {
     {MOD,      XK_q,   win_kill,   {0}},
@@ -22,7 +25,6 @@ static struct key keys[] = {
     {Mod1Mask|ShiftMask, XK_Tab, win_prev,   {0}},
 
     {MOD, XK_d,      run, {.com = menu}},
-    {MOD, XK_w,      run, {.com = colors}},
     {MOD, XK_p,      run, {.com = scrot}},
     {MOD, XK_Return, run, {.com = term}},
 

--- a/config.def.h
+++ b/config.def.h
@@ -26,6 +26,7 @@ static struct key keys[] = {
     {Mod1Mask|ShiftMask, XK_Tab, win_prev,   {0}},
 
     {MOD, XK_d,      run, {.com = menu}},
+    {MOD, XK_w,      run, {.com = colors}},
     {MOD, XK_p,      run, {.com = scrot}},
     {MOD, XK_Return, run, {.com = term}},
 

--- a/config.def.h
+++ b/config.def.h
@@ -15,6 +15,7 @@ const char* bridown[] = {"bri", "10", "-", 0};
 const char* voldown[] = {"amixer", "sset", "Master", "5%-",         0};
 const char* volup[]   = {"amixer", "sset", "Master", "5%+",         0};
 const char* volmute[] = {"amixer", "sset", "Master", "toggle",      0};
+const char* colors[]  = {"bud", "/home/goldie/Pictures/Wallpapers", 0};
 
 static struct key keys[] = {
     {MOD,      XK_q,   win_kill,   {0}},

--- a/sowm.c
+++ b/sowm.c
@@ -4,7 +4,6 @@
 #include <X11/XF86keysym.h>
 #include <X11/keysym.h>
 #include <X11/XKBlib.h>
-#include <X11/Xft/Xft.h>
 #include <stdlib.h>
 #include <signal.h>
 #include <unistd.h>

--- a/sowm.c
+++ b/sowm.c
@@ -45,13 +45,12 @@ void win_focus(client *c) {
 
     XSetWindowBorder(d, cur->w, getcolor(BORDER_SELECT));
 
-    if (cur->fs) XSetWindowBorder(d, cur->w, getcolor(BORDER_NONE));
-
     if (cur->fs) {
         XConfigureWindow(d, cur->w, CWBorderWidth, &(XWindowChanges){.border_width = 0});
     } else {
         XConfigureWindow(d, cur->w, CWBorderWidth, &(XWindowChanges){.border_width = BORDER_WIDTH});
     }
+    
     XSetInputFocus(d, cur->w, RevertToParent, CurrentTime);
 }
 

--- a/sowm.h
+++ b/sowm.h
@@ -30,9 +30,11 @@ typedef struct client {
     struct client *next, *prev;
     int f, wx, wy;
     unsigned int ww, wh;
+    unsigned char fs;
     Window w;
 } client;
 
+unsigned long getcolor(const char *col);
 void button_press(XEvent *e);
 void button_release(XEvent *e);
 void configure_request(XEvent *e);


### PR DESCRIPTION
This is a duct taped hacky way of adding focus on the existing borders patch.
Fullscreen windows have no borders. There is definitely a better way of doing this but this was the simplest I saw.

Few of the commits just me cleaning the code up after the fact.