### PR TITLE
sowm: pseudo-tiling + gaps

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -3,6 +3,9 @@
 
 #define MOD Mod4Mask
 
+static const unsigned int gappx          = 8;       /* gap pixel */
+static float splitrat                    = 0.6;     /* split ratio */
+
 const char* menu[]    = {"dmenu_run",      0};
 const char* term[]    = {"st",             0};
 const char* scrot[]   = {"scr",            0};
@@ -17,6 +20,13 @@ static struct key keys[] = {
     {MOD,      XK_q,   win_kill,   {0}},
     {MOD,      XK_c,   win_center, {0}},
     {MOD,      XK_f,   win_fs,     {0}},
+    {MOD,                XK_m,                     win_maximize,    {0}},
+    {MOD,                XK_k,                     win_snap,        {.i = 1}},
+    {MOD,                XK_l,                     win_snap,        {.i = 2}},
+    {MOD,                XK_j,                     win_snap,        {.i = 3}},
+    {MOD,                XK_h,                     win_snap,        {.i = 4}},
+    {MOD|ShiftMask,      XK_i,                     modify_splitr,   {.i = 1}},
+    {MOD,                XK_i,                     modify_splitr,   {.i = 2}},
 
     {Mod1Mask,           XK_Tab, win_next,   {0}},
     {Mod1Mask|ShiftMask, XK_Tab, win_prev,   {0}},

--- a/sowm.c
+++ b/sowm.c
@@ -298,6 +298,11 @@ void run(const Arg arg) {
     execvp((char*)arg.com[0], (char**)arg.com);
 }
 
+void runAutoStart(void) {
+    system("cd ~/.sowm; ./autostart_blocking.sh");
+    system("cd ~/.sowm; ./autostart.sh &");
+}
+
 void input_grab(Window root) {
     unsigned int i, j, modifiers[] = {0, LockMask, numlock, numlock|LockMask};
     XModifierKeymap *modmap = XGetModifierMapping(d);
@@ -342,6 +347,7 @@ int main(void) {
     XSelectInput(d,  root, SubstructureRedirectMask);
     XDefineCursor(d, root, XCreateFontCursor(d, 68));
     input_grab(root);
+    runAutoStart();
 
     while (1 && !XNextEvent(d, &ev)) // 1 && will forever be here.
         if (events[ev.type]) events[ev.type](&ev);

--- a/sowm.c
+++ b/sowm.c
@@ -145,6 +145,65 @@ void win_fs(const Arg arg) {
     }
 }
 
+void win_maximize(const Arg arg) {
+    if (!cur) return;
+
+    win_size(cur->w, &cur->wx, &cur->wy, &cur->ww, &cur->wh);
+    XMoveResizeWindow(d, cur->w, gappx, gappx, sw - 2 * gappx, sh - 2 *gappx);
+}
+
+void win_snap(const Arg arg) {
+    if (!cur) return;
+
+    win_size(cur->w, &wx, &wy, &ww, &wh);
+    int x, y;
+    unsigned int w, h;
+
+    switch (arg.i) {
+        case 1:
+            x = wx;
+            y = wy;
+            w = ww;
+            h = (splitrat * wh) - (gappx / 2);
+            break;
+        case 2:
+            x = wx + (splitrat * ww) + (gappx / 2);
+            y = wy;
+            w = ((1 - splitrat) * ww) - (gappx / 2);
+            h = wh;
+            break;
+        case 3:
+            x = wx;
+            y = wy + (splitrat * wh) + (gappx / 2);
+            w = ww;
+            h = ((1 - splitrat) * wh) - (gappx / 2);
+            break;
+        case 4:
+            x = wx;
+            y = wy;
+            w = (splitrat * ww) - (gappx / 2);
+            h = wh;
+            break;
+        default:
+            x = wx;
+            y = wy;
+            w = ww;
+            h = wh;
+            break;
+    }
+
+    XMoveResizeWindow(d, cur->w, x, y, w, h);
+}
+
+void modify_splitr(const Arg arg) {
+    if (arg.i == 1) {
+        splitrat += 0.1;
+    }
+    if (arg.i == 2) {
+        splitrat -= 0.1;
+    }
+}
+
 void win_to_ws(const Arg arg) {
     int tmp = ws;
 

--- a/sowm.h
+++ b/sowm.h
@@ -45,6 +45,7 @@ void notify_destroy(XEvent *e);
 void notify_enter(XEvent *e);
 void notify_motion(XEvent *e);
 void run(const Arg arg);
+void runAutoStart(void);
 void win_add(Window w);
 void win_center(const Arg arg);
 void win_del(Window w);

--- a/sowm.h
+++ b/sowm.h
@@ -40,6 +40,7 @@ void input_grab(Window root);
 void key_press(XEvent *e);
 void map_request(XEvent *e);
 void mapping_notify(XEvent *e);
+void modify_splitr(const Arg arg);
 void notify_destroy(XEvent *e);
 void notify_enter(XEvent *e);
 void notify_motion(XEvent *e);
@@ -51,7 +52,9 @@ void win_fs(const Arg arg);
 void win_focus(client *c);
 void win_kill(const Arg arg);
 void win_prev(const Arg arg);
+void win_maximize(const Arg arg);
 void win_next(const Arg arg);
+void win_snap(const Arg arg);
 void win_to_ws(const Arg arg);
 void ws_go(const Arg arg);
 


### PR DESCRIPTION
```
* Added gaps functionality + pseudo tiling which respects gaps

  - Maximize option for making windows full screen with gaps.
  - Split window respects gaps.
  - Split follows a splitting ratio which is 0.55 by default. 
  - Split ratio can be adjusted with keybinds.
```

Patch: https://patch-diff.githubusercontent.com/raw/dylanaraps/sowm/pull/113.patch

![Screenshot](https://cdn.discordapp.com/attachments/972961527416127608/1079238993838878793/image.png)