### PR TITLE
Resolve segfault on alt-tab after closing last window

### DIFF
--- a/sowm.c
+++ b/sowm.c
@@ -155,8 +155,8 @@ void win_to_ws(const Arg arg) {
     ws_save(arg.i);
 
     ws_sel(tmp);
-    win_del(cur->w);
     XUnmapWindow(d, cur->w);
+    win_del(cur->w);
     ws_save(tmp);
 
     if (list) win_focus(list);

--- a/sowm.c
+++ b/sowm.c
@@ -113,7 +113,7 @@ void win_del(Window w) {
     for win if (c->w == w) x = c;
 
     if (!list || !x)  return;
-    if (x->prev == x) list = 0;
+    if (x->prev == x) list = cur = 0;
     if (list == x)    list = x->next;
     if (x->next)      x->next->prev = x->prev;
     if (x->prev)      x->prev->next = x->next;


### PR DESCRIPTION
Resolves #112, where sowm would crash on win_next/win_prev after closing the last window in a workspace.